### PR TITLE
support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/mrhooray/crc-core-rs.git"
 license = "MIT"
 
 [dependencies]
+
+[features]
+std = []
+default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! core functions shared between source and build script of [crc](https://crates.io/crates/crc) crate
 
 pub fn make_table_crc32(poly: u32) -> [u32; 256] {


### PR DESCRIPTION
There needs to be a change in crc-rs so that the features are passed to crc-core. Not sure how to do that.